### PR TITLE
Browserify added to build, it generates one js file to use in browser.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.15",
   "main": "dist/index.js",
   "scripts": {
-    "build": "rimraf dist && tsc; browserify ./dist/browser-main.js -o ./dist/raml-suggestions.js;",
+    "build": "rimraf dist && tsc",
+    "browserify" : "browserify ./dist/browser-main.js -o ./dist/raml-suggestions.js;",
     "test-cov": " ./node_modules/.bin/istanbul cover _mocha dist/test/*Tests.js"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.15",
   "main": "dist/index.js",
   "scripts": {
-    "build": "rimraf dist && tsc",
+    "build": "rimraf dist && tsc; browserify ./dist/browser-main.js -o ./dist/raml-suggestions.js;",
     "test-cov": " ./node_modules/.bin/istanbul cover _mocha dist/test/*Tests.js"
   },
   "repository": {
@@ -22,6 +22,15 @@
     "mocha": "^2.2.1",
     "istanbul": "^0.4.2",
     "typescript": "1.8.7",
-    "rimraf": "*"
+    "rimraf": "*",
+    "browserify-global-shim": "^1.0.3"
+  },
+  "browserify": {
+    "transform": [
+      "browserify-global-shim"
+    ]
+  },
+  "browserify-global-shim": {
+    "raml-1-parser": "RAML.Parser"
   }
 }

--- a/src/browser-main.ts
+++ b/src/browser-main.ts
@@ -1,2 +1,2 @@
-window['RAML'] = window['RAML'] || {};
-window['RAML'].Suggestions = require('./index');
+(<any>window)[<any>'RAML'] = window[<any>'RAML'] || {};
+(<any>window)[<any>'RAML'].Suggestions = require('./index');

--- a/src/browser-main.ts
+++ b/src/browser-main.ts
@@ -1,0 +1,2 @@
+window['RAML'] = window['RAML'] || {};
+window['RAML'].Suggestions = require('./index');


### PR DESCRIPTION
This commits add a browser-main.ts, with the purpose of being used to generate a js distribution for the browser with browserify. The browserify configuration to use the parser as a global variable is also added in de package.json.
